### PR TITLE
Get context data from superclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# PyCharm project settings
+.idea
+
 *.sqlite3
 demo/media/*
 src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2019-12-01
+### Changed
+
+- `get_context_data` now calls the `super()` method to keep context data intact from other superclasses and mix-ins
+
 ## [2.0.1] - 2018-01-27
 ### Changed
 - `get` and `forms_invalid` have been updated to call `render_to_response` instead of `render`

--- a/multi_form_view/base.py
+++ b/multi_form_view/base.py
@@ -43,12 +43,12 @@ class MultiFormView(FormView):
         """
         Add forms into the context dictionary.
         """
-        context = {}
         if 'forms' not in kwargs:
-            context['forms'] = self.get_forms()
-        else:
-            context['forms'] = kwargs['forms']
-        return context
+            kwargs['forms'] = self.get_forms()
+        # Override "form" if not present so the original FormView class doesn't try to get a singular form.
+        if 'form' not in kwargs:
+            kwargs['form'] = None
+        return super(MultiFormView, self).get_context_data(**kwargs)
 
     def get_forms(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 setup(
     name='django-multi-form-view',
-    version='2.0.1',
+    version='2.0.2',
     author=u'Tim Best',
     packages=find_packages(),
     url='https://github.com/TimBest/django-multi-form-view',


### PR DESCRIPTION
Original implementation did not call super().get_context_data so extra context data from superclasses and other mix-ins was lost.  This appeared to be in order to avoid the issue of the regular FormView class trying to get a singular form class since MultiFormView was subclassed from it, but this can be avoided by setting the "form" field in kwargs to None if it's not present instead.  This keeps the extra context data intact and conforms to other Django context mix-in classes.